### PR TITLE
Remove dialog icon from updater

### DIFF
--- a/src/browser/auto-update-manager.coffee
+++ b/src/browser/auto-update-manager.coffee
@@ -17,10 +17,12 @@ class AutoUpdateManager
 
   constructor: (@version) ->
     @state = IdleState
+    @iconPath = path.resolve(__dirname, '..', '..', 'resources', 'atom.png');
     if process.platform is 'win32'
       # Squirrel for Windows can't handle query params
       # https://github.com/Squirrel/Squirrel.Windows/issues/132
       @feedUrl = 'https://atom.io/api/updates'
+      @iconPath = null;
     else
       @feedUrl = "https://atom.io/api/updates?version=#{@version}"
 
@@ -89,7 +91,7 @@ class AutoUpdateManager
     dialog.showMessageBox
       type: 'info'
       buttons: ['OK']
-      icon: path.resolve(__dirname, '..', '..', 'resources', 'atom.png')
+      icon: @iconPath
       message: 'No update available.'
       title: 'No Update Available'
       detail: "Version #{@version} is the latest version."
@@ -100,7 +102,7 @@ class AutoUpdateManager
     dialog.showMessageBox
       type: 'warning'
       buttons: ['OK']
-      icon: path.resolve(__dirname, '..', '..', 'resources', 'atom.png')
+      icon: @iconPath
       message: 'There was an error checking for updates.'
       title: 'Update Error'
       detail: message


### PR DESCRIPTION
addresses  atom/atom#5670
Remove the update icon on windows when showing the update modal dialog.
Keep the icon for linux. This appears to be the only file outside of
`build/` that uses the `'atom.png'` file.